### PR TITLE
SW-5342: Adds gov assets path

### DIFF
--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -1,6 +1,7 @@
 $govuk-include-default-font-face: false;
 $govuk-moj-table-background-color: #e7f2fb;
 $moj-assets-path: "/supervision/deputies/professional/assets/";
+$govuk-assets-path: "/supervision/deputies/professional/assets/";
 
 @import "node_modules/govuk-frontend/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";

--- a/web/template/clients.gotmpl
+++ b/web/template/clients.gotmpl
@@ -1,7 +1,6 @@
 {{ template "page" . }}
 {{ define "main" }}
    {{ template "pro-deputy" . }}
-   {{ template "navigation" . }}
    <div class="main">
     <header>
         <h1 class="govuk-heading-l  govuk-!-margin-bottom-0  govuk-!-margin-top-0">Clients</h1>


### PR DESCRIPTION
The gov assets path in the SCSS was not copied over from PA Deputy Hub, which resulted in one of the images from the govuk stylings not fetching from `https://live.sirius-opg.uk/supervision/deputies/professional/assets` but `http://live.sirius-opg.uk/assets`. This resulted in Sirius returning a 401 for the image, effectively logging the user out. 

However, as the requests for data are made on the server and the HTML rendered server-side prior to fetching front end assets, the page would load as expected the first time it was accessed. Any further action from the user (e.g. clicking a nav link), would result in them being thrown to the login page.

During testing, I also noticed the client tab had a duplicate nav bar in error. As it was a single line change, I've included it here.