### PR TITLE
Fixes 404 handling on routes that aren't handled.

### DIFF
--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -1,0 +1,6 @@
+describe("Error handling", () => {
+  it("renders the error page when the URL does not match a valid route", () => {
+    cy.visit("/supervision/deputies/professional/client/1");
+    cy.contains(".govuk-heading-l", "Page not found");
+  });
+});


### PR DESCRIPTION
Current behaviour just outputs a plaintext not found message, rather than the expected error page, which is only shown if a matching route has a 404 returned from Sirius.