### PR TITLE
Pin colors to 1.4.0 #patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
         "test-server": "cd internal/server && go test",
         "cypress": "cypress open",
         "fmt": "prettier --write ."
+    },
+    "resolutions": {
+        "colors": "1.4.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,7 +1520,7 @@ colorette@^2.0.14, colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
To ensure we avoid a security issue in >1.4.4.

Can be removed when the package is back under secure control, or our core dependencies stop using it.