### PR TITLE
SW-5446 add deputy status flag to pro hub

### DIFF
--- a/cypress/integration/pro_deputy_hub.spec.js
+++ b/cypress/integration/pro_deputy_hub.spec.js
@@ -47,7 +47,7 @@ describe("Pro Deputy Hub", () => {
         });
     });
 
-    describe("Pro deputy details", () => {
+    describe("Pro Person deputy details", () => {
         it("the page should contain the deputy name", () => {
             cy.contains(".hook_header_deputy_name", "firstname surname");
         });
@@ -88,6 +88,20 @@ describe("Pro Deputy Hub", () => {
                     cy.wrap(el).contains(expected[i]);
                 }
             });
+        });
+    });
+
+    describe("Pro Organisation details", () => {
+        beforeEach(() => {
+            cy.visit("/supervision/deputies/professional/deputy/2");
+        });
+
+        it("the page should contain the deputy name", () => {
+            cy.contains(".hook_header_organisation_name", "Organisation Ltd");
+        });
+
+        it("the page should contain the deputy status", () => {
+            cy.contains(".hook_header_deputy_status_organisation", "Inactive");
         });
     });
 });

--- a/cypress/integration/pro_deputy_hub.spec.js
+++ b/cypress/integration/pro_deputy_hub.spec.js
@@ -52,6 +52,10 @@ describe("Pro Deputy Hub", () => {
             cy.contains(".hook_header_deputy_name", "firstname surname");
         });
 
+        it("the page should contain the deputy status", () => {
+            cy.contains(".hook_header_deputy_status_person", "Active");
+        });
+
         it("the page should contain the firm", () => {
             cy.contains(".hook_header_firm_name", "This is the Firm Name");
         });

--- a/internal/sirius/get_pro_deputy.go
+++ b/internal/sirius/get_pro_deputy.go
@@ -26,6 +26,7 @@ type ProDeputyDetails struct {
 	DeputySurname                    string               `json:"surname"`
 	DeputyNumber                     int                  `json:"deputyNumber"`
 	DeputySubType                    deputySubType        `json:"deputySubType"`
+	DeputyStatus                     string               `json:"deputyStatus"`
 	OrganisationName                 string               `json:"organisationName"`
 	OrganisationTeamOrDepartmentName string               `json:"organisationTeamOrDepartmentName"`
 	ExecutiveCaseManager             executiveCaseManager `json:"executiveCaseManager"`

--- a/internal/sirius/get_pro_deputy_test.go
+++ b/internal/sirius/get_pro_deputy_test.go
@@ -20,6 +20,7 @@ func TestProDeputyDetailsReturned(t *testing.T) {
 		"firstname": "firstname",
 		"surname": "surname",
 		"deputyNumber": 1000,
+		"deputyStatus": "INACTIVE",
 		"organisationName": "organisationName",
 		"executiveCaseManager": {
 			"id": 223,
@@ -44,6 +45,7 @@ func TestProDeputyDetailsReturned(t *testing.T) {
 		DeputyFirstName:  "firstname",
 		DeputySurname:    "surname",
 		DeputyNumber:     1000,
+		DeputyStatus:     "INACTIVE",
 		OrganisationName: "organisationName",
 		ExecutiveCaseManager: executiveCaseManager{
 			EcmId:   223,
@@ -75,6 +77,7 @@ func TestGetDeputyDetailsReturnsNewStatusError(t *testing.T) {
 		DeputyFirstName:  "",
 		DeputySurname:    "",
 		DeputyNumber:     0,
+		DeputyStatus:     "",
 		OrganisationName: "",
 		ExecutiveCaseManager: executiveCaseManager{
 			EcmId:   0,
@@ -105,6 +108,7 @@ func TestGetDeputyDetailsReturnsUnauthorisedClientError(t *testing.T) {
 		DeputyFirstName:  "",
 		DeputySurname:    "",
 		DeputyNumber:     0,
+		DeputyStatus:     "",
 		OrganisationName: "",
 		ExecutiveCaseManager: executiveCaseManager{
 			EcmId:   0,

--- a/json-server/db.json
+++ b/json-server/db.json
@@ -157,7 +157,8 @@
       "deputySubType": {
         "handle": "ORGANISATION",
         "label": "Organisation"
-      }
+      },
+      "deputyStatus": "Inactive"
     }
   ],
   "clients": {

--- a/web/template/layout/pro-deputy.gotmpl
+++ b/web/template/layout/pro-deputy.gotmpl
@@ -6,11 +6,19 @@
                 <h2
                     class="govuk-heading-m govuk-!-margin-bottom-0 hook_header_deputy_name">
                     {{ printf "%v %v" .ProDeputyDetails.DeputyFirstName .ProDeputyDetails.DeputySurname }}
+                    <span
+                        class="moj-badge govuk-!-margin-left-2 hook_header_deputy_status_person">
+                        {{ .ProDeputyDetails.DeputyStatus }}</span
+                    >
                 </h2>
             {{ else }}
                 <h2
                     class="govuk-heading-m govuk-!-margin-bottom-0 hook_header_organisation_name">
                     {{ .ProDeputyDetails.OrganisationName }}
+                    <span
+                        class="moj-badge govuk-!-margin-left-2 hook_header_deputy_status_organisation">
+                        {{ .ProDeputyDetails.DeputyStatus }}</span
+                    >
                 </h2>
             {{ end }}
             <span


### PR DESCRIPTION
This PR is to add the deputy status fly to the professional hub so it displays as a badge next to the professional deputies name. 