### PR TITLE
SW-5476 Add Firm link to deputy details tab

### DIFF
--- a/cypress/integration/change_firm.spec.js
+++ b/cypress/integration/change_firm.spec.js
@@ -37,7 +37,7 @@ describe("Change Firm", () => {
         });
 
         it("has a cancel button that can redirect to deputy details page", () => {
-            cy.get(".govuk-link").should("contain", "Cancel").click();
+            cy.contains(".govuk-link", "Cancel").click();
             cy.url().should(
                 "contain",
                 "/supervision/deputies/professional/deputy/1"

--- a/cypress/integration/manage_important_information.spec.js
+++ b/cypress/integration/manage_important_information.spec.js
@@ -21,7 +21,7 @@ describe("Manage important Information", () => {
 
         it("shows a cancel button which returns me to the dashboard", () => {
             cy.visit("/supervision/deputies/professional/deputy/1/manage-important-information");
-            cy.get(".govuk-link").should("contain", "Cancel").click();
+            cy.contains(".govuk-link", "Cancel").click();
             cy.url().should(
                 "not.contain",
                 "/supervision/deputies/professional/deputy/1/manage-important-information"

--- a/cypress/integration/pro_deputy_details.spec.js
+++ b/cypress/integration/pro_deputy_details.spec.js
@@ -7,9 +7,13 @@ describe("Pro Deputy Hub", () => {
 
     describe("Deputy details", () => {
         it("shows all the deputy details", () => {
-            cy.get(".hook_deputy_name").contains("firstname surname");
-            cy.get(".hook_deputy_phone_number").contains("1111111");
-            cy.get(".hook_deputy_email").contains("email@something.com");
+            cy.contains(".hook_deputy_name", "firstname surname");
+            cy.contains(".hook_deputy_firm_name", "This is the Firm Name")
+                .find('a')
+                .should("have.attr", "href")
+                .and('contain', "/supervision/deputies/firm/0");
+            cy.contains(".hook_deputy_phone_number", "1111111");
+            cy.contains(".hook_deputy_email", "email@something.com");
         });
     });
 });

--- a/cypress/integration/pro_deputy_hub.spec.js
+++ b/cypress/integration/pro_deputy_hub.spec.js
@@ -57,7 +57,10 @@ describe("Pro Deputy Hub", () => {
         });
 
         it("the page should contain the firm", () => {
-            cy.contains(".hook_header_firm_name", "This is the Firm Name");
+            cy.contains(".hook_header_firm_name", "This is the Firm Name")
+                .find('a')
+                .should("have.attr", "href")
+                .and('contain', "/supervision/deputies/firm/0");
         });
 
         it("the page should contain the deputy number", () => {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,5 +9,5 @@ services:
     environment:
       SIRIUS_URL: http://docker.for.mac.localhost:8080
       SIRIUS_PUBLIC_URL: http://localhost:8080
-      FIRM_HUB_URL: http://localhost:8887
+      FIRM_HUB_URL: http://localhost:8887/supervision/deputies/firm
       PREFIX: /supervision/deputies/professional

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	webDir := getEnv("WEB_DIR", "web")
 	siriusURL := getEnv("SIRIUS_URL", "http://localhost:8080")
 	siriusPublicURL := getEnv("SIRIUS_PUBLIC_URL", "")
-	firmHubURL := getEnv("FIRM_HUB_URL", "")
+	firmHubURL := getEnv("FIRM_HUB_URL", "/supervision/deputies/firm")
 	prefix := getEnv("PREFIX", "")
 
 	layouts, _ := template.

--- a/web/template/layout/pro-deputy.gotmpl
+++ b/web/template/layout/pro-deputy.gotmpl
@@ -25,8 +25,8 @@
                 class="govuk-caption-m  govuk-!-margin-bottom-0 hook_header_firm_name">
                 Firm:
                 <a
-                    class="moj-header__navigation-link"
-                    href="{{ firmhub (printf "/supervision/deputies/firm/%d" .ProDeputyDetails.Firm.FirmId) }}">
+                    class="govuk-link"
+                    href="{{ firmhub (printf "/%d" .ProDeputyDetails.Firm.FirmId) }}">
                     {{ printf "%v" .ProDeputyDetails.Firm.FirmName }}</a
                 >
             </span>

--- a/web/template/pro-dashboard.gotmpl
+++ b/web/template/pro-dashboard.gotmpl
@@ -54,7 +54,11 @@
                     <dt class="govuk-summary-list__key">Firm</dt>
                     <dd class="govuk-summary-list__value hook_deputy_firm_name">
                         {{ if ne .ProDeputyDetails.Firm.FirmName "" }}
-                            {{ .ProDeputyDetails.Firm.FirmName }}
+                            <a
+                                class="govuk-link"
+                                href="{{ firmhub (printf "/%d" .ProDeputyDetails.Firm.FirmId) }}">
+                                {{ printf "%v" .ProDeputyDetails.Firm.FirmName }}</a
+                            >
                         {{ end }}
                     </dd>
                 </div>


### PR DESCRIPTION
- Make Firm Name a link in the deputy details tab
- Restyle the Firm link in the summary so it's more obvious